### PR TITLE
Remove NeilLuno from Renovate reviewers

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,16 +1,16 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'config:recommended',
   ],
-  "branchConcurrentLimit": 3,
-  "labels": [
-    "Bot::Renovate"
+  branchConcurrentLimit: 3,
+  labels: [
+    'Bot::Renovate',
   ],
-  "semanticCommits": "disabled",
-  "commitMessagePrefix": "renovate:",
-  "reviewers": [
-    "echarrod",
-    "adamhicks"
-  ]
+  semanticCommits: 'disabled',
+  commitMessagePrefix: 'renovate:',
+  reviewers: [
+    'echarrod',
+    'adamhicks',
+  ],
 }


### PR DESCRIPTION
This PR removes NeilLuno from the Renovate reviewers list as he has left the company.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated dependency management configuration to remove one reviewer from the configured reviewer list. The reviewer roster now includes only the remaining nominated reviewers, so future automated reviewer assignments will exclude the removed individual. This change does not affect functionality for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->