### PR TITLE
fix: Raise error for non-JSON-serializable parameters

### DIFF
--- a/luno_python/base_client.py
+++ b/luno_python/base_client.py
@@ -76,7 +76,7 @@ class BaseClient:
             try:
                 params = json.loads(json.dumps(req))
             except TypeError as e:
-                raise TypeError("luno: request parameters must be JSON-serializable: %s" % str(e))
+                raise TypeError("luno: request parameters must be JSON-serializable: %s" % str(e)) from e
         headers = {"User-Agent": self.make_user_agent()}
         args = dict(timeout=self.timeout, params=params, headers=headers)
         if auth:

--- a/luno_python/base_client.py
+++ b/luno_python/base_client.py
@@ -70,10 +70,13 @@ class BaseClient:
         :type req: object
         :type auth: bool
         """
-        try:
-            params = json.loads(json.dumps(req))
-        except Exception:
+        if req is None:
             params = None
+        else:
+            try:
+                params = json.loads(json.dumps(req))
+            except TypeError as e:
+                raise TypeError("luno: request parameters must be JSON-serializable: %s" % str(e))
         headers = {"User-Agent": self.make_user_agent()}
         args = dict(timeout=self.timeout, params=params, headers=headers)
         if auth:


### PR DESCRIPTION
## Summary

Fixes #69 by providing clear error messages when request parameters cannot be serialized to JSON, instead of silently suppressing the error and returning a confusing API error.

Previously, passing non-JSON-serializable types (like `Decimal`) would silently fail and set `params` to `None`, causing misleading API errors. Now, a clear `TypeError` is raised immediately pointing to the serialization issue.

## Changes

- Modified `BaseClient.do()` to catch only `TypeError` instead of suppressing all exceptions
- Raises descriptive error message for non-serializable parameters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer error message when request parameters cannot be JSON-serialised.
  * Graceful handling of empty requests so no unnecessary processing is attempted.

* **Tests**
  * Added tests verifying non-serialisable parameters raise a descriptive error and that empty requests are handled without error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->