### PR TITLE
release: bump version to 0.3.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
+          cache: pip
 
       - name: Install build dependencies
         run: python -m pip install --upgrade pip build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: python -m pip install --upgrade pip build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for trusted publishing
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,4 +46,4 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,8 +96,8 @@ This project is published to [PyPI](https://pypi.org/project/luno-python/). Rele
    git checkout main && git pull origin main
    gh release create vx.y.z --title "vx.y.z" --generate-notes
    ```
-   This triggers the publish workflow which automatically builds and uploads the package to PyPI.
+   This triggers the publishing workflow, which automatically builds and uploads the package to PyPI.
 
 ### PyPI Trusted Publishing
 
-The publish workflow uses [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OpenID Connect), which means no API tokens need to be stored as secrets. This must be configured once in PyPI's project settings under *Publishing → Add a new publisher*, pointing at this repository's `publish.yml` workflow.
+The publishing workflow uses [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OpenID Connect), which means no API tokens need to be stored as secrets. This must be configured once in PyPI's project settings under *Publishing → Add a new publisher*, pointing at this repository's `publish.yml` workflow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,3 +64,40 @@ git commit --no-verify
 ```bash
 pytest
 ```
+
+## Releasing
+
+This project is published to [PyPI](https://pypi.org/project/luno-python/). Releases are made by maintainers with repository write access and PyPI publish access.
+
+### Steps
+
+1. **Decide the version number** following [Semantic Versioning](https://semver.org/):
+   - Patch (`x.y.Z`): backwards-compatible bug fixes
+   - Minor (`x.Y.0`): new backwards-compatible functionality
+   - Major (`X.0.0`): breaking changes
+
+2. **Bump the version** in `luno_python/__init__.py`:
+   ```python
+   VERSION = "x.y.z"
+   ```
+
+3. **Commit and push** the version bump on a branch, then open and merge a PR:
+   ```bash
+   git checkout -b release-x.y.z
+   git add luno_python/__init__.py
+   git commit -m "release: bump version to x.y.z"
+   git push origin release-x.y.z
+   gh pr create --title "release: bump version to x.y.z" --body "Bump version for release."
+   # After review, merge the PR
+   ```
+
+4. **Create a GitHub Release** from the merged commit on `main`:
+   ```bash
+   git checkout main && git pull origin main
+   gh release create vx.y.z --title "vx.y.z" --generate-notes
+   ```
+   This triggers the publish workflow which automatically builds and uploads the package to PyPI.
+
+### PyPI Trusted Publishing
+
+The publish workflow uses [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OpenID Connect), which means no API tokens need to be stored as secrets. This must be configured once in PyPI's project settings under *Publishing → Add a new publisher*, pointing at this repository's `publish.yml` workflow.

--- a/luno_python/__init__.py
+++ b/luno_python/__init__.py
@@ -1,3 +1,3 @@
 """Luno Python SDK."""
 
-VERSION = "0.0.10"
+VERSION = "0.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ skip_gitignore = true
 exclude_dirs = ["tests", "env", "build"]
 skips = [
     "B101",  # Skip assert_used check (common in tests)
-    "B107",  # Skip hardcoded_password_default (empty string defaults are acceptable for optional credentials)
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Fixes #78.

## Summary

- Bumps `VERSION` to `0.3.0` (PyPI has been stuck at `0.0.10` despite tags `v0.1.0` and `v0.2.0` existing — the version was never bumped in code and nothing was published)
- Adds a **Releasing** section to `CONTRIBUTING.md` documenting the end-to-end process
- Adds `.github/workflows/publish.yml`: builds and publishes to PyPI automatically when a GitHub Release is created, using PyPI Trusted Publishing (OIDC — no stored secrets needed)
- Removes unrecognised `B107` bandit skip (was causing pre-commit failures)

## Next step after merging

Set up [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) on PyPI for this repo, then:

```bash
git checkout main && git pull origin main
gh release create v0.3.0 --title "v0.3.0" --generate-notes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.3.0
  * Added automated publishing workflow for PyPI using trusted publishing

* **Documentation**
  * Added a “Releasing” section detailing release steps, semantic versioning, and trusted-publishing setup

* **Security**
  * Re-enabled static-analysis check so hardcoded-password detection runs during scans
<!-- end of auto-generated comment: release notes by coderabbit.ai -->