### PR TITLE
renovate: update PR reviewers

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -10,7 +10,7 @@
   semanticCommits: 'disabled',
   commitMessagePrefix: 'renovate:',
   reviewers: [
-    'echarrod',
-    'adamhicks',
+    'RieshBissessur',
+    'andrewwormald',
   ],
 }


### PR DESCRIPTION
Replaces `echarrod` and `adamhicks` as Renovate reviewers with `RieshBissessur` and `andrewwormald`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration for dependency management review assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->